### PR TITLE
Add dYdX client usage details

### DIFF
--- a/PORT_INFO.md
+++ b/PORT_INFO.md
@@ -8,6 +8,13 @@ The README outlines a three-phase approach:
 2. **Python Bridge & Market-Data Path** – expose Rust clients to Python via `pyo3` and route the `MarketDataClient` through the Rust implementation, transparently for users.
 3. **Full Adapter in Rust** – re-implement `InstrumentProvider`, `DataClient`, and `ExecutionClient` in Rust, refactor order submission methods, and run latency and soak tests.
 
+### Existing dYdX Clients
+The current adapter already provides three separate transport clients:
+- **HTTP** – used for historical data queries and instrument metadata.
+- **WebSocket** – streams market data such as order book updates.
+- **gRPC** – required for order submission and fee rate requests.
+These will be replaced by strongly typed Rust equivalents as work progresses.
+
 ## References and Links
 - The README indicates that this repository integrates dYdX with Nautilus Trader.
 - Commit `84738a4` references a merge of pull request `#1` titled "Add basic implementation plan".

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This repository provides code and documentation for integrating dYdX with Nautilus Trader.
 
+## dYdX API Components
+
+The dYdX exchange exposes multiple APIs that serve distinct purposes:
+
+- **HTTP (REST)** – used for retrieving historical market data and instrument metadata.
+- **WebSocket** – provides streaming market data so clients can watch real-time order book updates and ticker changes.
+- **gRPC** – required for submitting orders and requesting fee rates.
+
+At present the project includes basic clients for each of these protocols. Future work will replace the current Python adapter with a set of strongly typed Rust implementations.
+
 ## Implementation Plan
 
 Below is a high-level TODO list for the planned work:

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,13 @@ This file tracks tasks required to implement a Rust-based adapter for NautilusTr
 - **Execution Client**: handle order submission, modification, cancellation, and report generation.
 - **Configuration**: define settings required by the Rust clients (API keys, base URLs, etc.).
 
+## dYdX API Notes
+- The existing adapter already includes three transport clients:
+  - **HTTP** for historical data and instrument metadata.
+  - **WebSocket** for real-time market data streams.
+  - **gRPC** for submitting orders and querying fee rates.
+  These clients will be replaced with typed Rust equivalents during the port.
+
 ## Porting Steps
 1. Create Rust crates for the clients above, following existing Python interfaces.
 2. Reuse strongly typed transport clients from Phase 1 for HTTP/WebSocket/gRPC.


### PR DESCRIPTION
## Summary
- document how HTTP, WebSocket and gRPC are used for dYdX
- note existing clients in TODO list
- add details in port information overview

## Testing
- `cargo test` *(fails: could not find `Cargo.toml`)*
- `pytest` *(fails: command not found)*