### PR TITLE
Add links to main nautilus-trader repo

### DIFF
--- a/LINKS_TO_REMOTE.md
+++ b/LINKS_TO_REMOTE.md
@@ -1,0 +1,7 @@
+This file lists links to relevant adapter patterns and pull requests in the main Nautilus Trader repository.
+
+- Main repository: https://github.com/nautechsystems/nautilus_trader
+- dYdX adapter planning: [PR #1951](https://github.com/nautechsystems/nautilus_trader/pull/1951)
+- OKX port PR example: [PR #2610](https://github.com/nautechsystems/nautilus_trader/pull/2610)
+
+Additional modules for existing adapters can be found in the `nautilus_trader/adapters` directory of the main repository.


### PR DESCRIPTION
## Summary
- include a new doc referencing important pull requests in the main Nautilus Trader repo

## Testing
- `pytest -q` *(fails: command not found)*